### PR TITLE
Changed sites-enabled to sites-available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN mv composer.phar /usr/local/bin/composer
 
 # Copy across the local files to the root directory
 ADD . /var/www/html/
-ADD ./server/apache-vhost.conf /etc/apache2/sites-enabled/000-default.conf
+ADD ./server/apache-vhost.conf /etc/apache2/sites-available/000-default.conf
 ADD ./server/php-config.ini /usr/local/etc/php/conf.d/php-config.ini
 RUN chmod +x /var/www/html/start.sh
 RUN cd /var/www/html && composer install


### PR DESCRIPTION
The proper path to change the config files in apache is `sites-available`. As in `sites-enabled` only symlinks are used. In this case, `000-default.conf` is already linking by default. So only the original file is needed to be updated.